### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/netease/util/InodeUtil.java
+++ b/src/main/java/com/netease/util/InodeUtil.java
@@ -8,6 +8,9 @@ import java.io.IOException;
  * @author jiaozhihui@corp.netease.com
  */
 public class InodeUtil {
+    
+    private InodeUtil() {}
+    
     static {
         try {
             NativeLoader.loadLibrary("inodeutil");

--- a/src/main/java/com/netease/util/NativeLoader.java
+++ b/src/main/java/com/netease/util/NativeLoader.java
@@ -24,6 +24,8 @@ import java.io.IOException;
  */
 public class NativeLoader {
     private static JniExtractor jniExtractor = new DefaultJniExtractor();
+    
+    private NativeLoader() {}
 
     /**
      * Extract the given library from a jar, and load it.

--- a/src/main/java/com/netease/util/tailer/TailerHelper.java
+++ b/src/main/java/com/netease/util/tailer/TailerHelper.java
@@ -18,6 +18,8 @@ public class TailerHelper {
      * Default buffer size for reading.
      */
     private static final int DEFAULT_BUFSIZE = 4096;
+    
+    private TailerHelper() {}
 
     /**
      * Creates a Tailer for the given file, starting from the beginning, with


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
